### PR TITLE
Fix echoing characters while typing in saving and remove unneeded headers

### DIFF
--- a/headers/headers.h
+++ b/headers/headers.h
@@ -4,4 +4,3 @@
 #include <unistd.h>
 #include <locale.h>
 #include <sys/stat.h>
-#include <omp.h>

--- a/main.cpp
+++ b/main.cpp
@@ -144,12 +144,12 @@ read:
 
 		case SAVE:
 			if (strlen(filename) == 0) {
-				wclear(header_win);
-				wmove(header_win, 0, 0);
-				waddnstr(header_win, "Enter filename: ", 17);
-				wrefresh(header_win);
-				wmove(header_win, 0, 15);
+				print_header();
+				print2header("Enter filename: ", 1);
+				wmove(header_win, 0, 16);
 				//wscanw(header_win, "%s", filename);
+
+				echo();
 				if (wgetnstr(header_win, filename, FILENAME_MAX) == ERR ||
 				    strlen(filename) == 0) {
 					print_header();

--- a/main.cpp
+++ b/main.cpp
@@ -158,6 +158,7 @@ read:
 					break;
 				}
 			}
+			noecho();
 			fo = fopen(filename, "w");
 			for (unsigned char i = 0; i <= curnum; ++i)
 #if defined(UNICODE)

--- a/main.cpp
+++ b/main.cpp
@@ -144,7 +144,7 @@ read:
 
 		case SAVE:
 			if (strlen(filename) == 0) {
-				print_header();
+				clear_header();
 				print2header("Enter filename: ", 1);
 				wmove(header_win, 0, 16);
 				//wscanw(header_win, "%s", filename);
@@ -152,7 +152,7 @@ read:
 				echo();
 				if (wgetnstr(header_win, filename, FILENAME_MAX) == ERR ||
 				    strlen(filename) == 0) {
-					print_header();
+					reset_header();
 					print2header("ERROR", 1);
 					wmove(text_win, y, x);
 					break;
@@ -168,7 +168,7 @@ read:
 #endif
 			fclose(fo);
 
-			print_header();
+			reset_header();
 			print2header("Saved", 1);
 			wmove(text_win, y, x);
 			break;
@@ -196,7 +196,7 @@ read:
 		case KEY_RESIZE:
 		case REFRESH:
 			getmaxyx(text_win, maxy, maxx);
-			print_header();
+			reset_header();
 			print_text();
 			print_lines();
 			ofy = 0;

--- a/utils/init.c
+++ b/utils/init.c
@@ -12,7 +12,7 @@ void init_header()
 {
 	header_win = newwin(1, maxx, 0, 0);
 	wattrset(header_win, A_STANDOUT);
-	print_header();
+	reset_header();
 }
 
 void init_lines()

--- a/utils/io.cpp
+++ b/utils/io.cpp
@@ -10,13 +10,21 @@ void print_lines()
 	} while (--i != 0);
 }
 
-void print_header()
+void clear_header()
 {
 	wmove(header_win, 0, 0);
 	for (short i = maxx;  i != 0; --i)
 		waddch(header_win, ' ');
-	mvwprintw(header_win, 0, maxx / 2 - 9, "%s", name);
 	wrefresh(header_win);
+}
+
+void print_header_title() {
+	mvwprintw(header_win, 0, maxx / 2 - 9, "%s", name);
+}
+
+void reset_header() {
+	clear_header();
+	print_header_title();
 }
 
 // pos: (1 left) (3 right) (else center)

--- a/utils/io.cpp
+++ b/utils/io.cpp
@@ -20,6 +20,7 @@ void clear_header()
 
 void print_header_title() {
 	mvwprintw(header_win, 0, maxx / 2 - 9, "%s", name);
+	wrefresh(header_win);
 }
 
 void reset_header() {

--- a/utils/io.cpp
+++ b/utils/io.cpp
@@ -18,12 +18,12 @@ void clear_header()
 	wrefresh(header_win);
 }
 
-void print_header_title() {
+inline void print_header_title() {
 	mvwprintw(header_win, 0, maxx / 2 - 9, "%s", name);
 	wrefresh(header_win);
 }
 
-void reset_header() {
+inline void reset_header() {
 	clear_header();
 	print_header_title();
 }


### PR DESCRIPTION
When I hit Ctrl-S to save and try to enter the filename, what I type doesn't show on screen. Also, there is an unused `<omp.h>` in the `headers/headers.h` file.